### PR TITLE
feat: add Silhouette scene — texture-driven raymarched tunnel

### DIFF
--- a/src/components/visualizer/scenes/grid-scene.ts
+++ b/src/components/visualizer/scenes/grid-scene.ts
@@ -4,6 +4,10 @@ import { registerScene } from './scene-registry';
 import {
   TEXTURE_UNIFORMS,
   TEXTURE_SAMPLE_FN,
+  PARTICLE_SHAPE_UNIFORM,
+  PARTICLE_SHAPE_FN,
+  PARTICLE_SHAPE_INDEX,
+  PARTICLE_SHAPE_PARAM,
   createTextureUniforms,
   applyTextureTransform,
 } from './shader-chunks';
@@ -81,6 +85,8 @@ export class GridScene {
   private static FRAGMENT = `
     ${TEXTURE_UNIFORMS}
     ${TEXTURE_SAMPLE_FN}
+    ${PARTICLE_SHAPE_UNIFORM}
+    ${PARTICLE_SHAPE_FN}
     uniform float uHigh;
     uniform vec3 uPrimary;
     uniform vec3 uSecondary;
@@ -101,10 +107,8 @@ export class GridScene {
         alpha = texSample.a;
         if (alpha < 0.01) discard;
       } else {
-        if (d > 0.5) discard;
-        // Soft square-ish shape for grid feel
-        float softEdge = 1.0 - smoothstep(0.3, 0.5, d);
-        alpha = softEdge * 0.9;
+        alpha = particleShapeAlpha(gl_PointCoord, uParticleShape) * 0.9;
+        if (alpha < 0.01) discard;
       }
 
       // Color sweep: primary -> secondary -> accent -> primary
@@ -174,6 +178,10 @@ export class GridScene {
         uPrimary: { value: new THREE.Color(palette.primary) },
         uSecondary: { value: new THREE.Color(palette.secondary) },
         uAccent: { value: new THREE.Color(palette.accent) },
+        uParticleShape: {
+          value:
+            PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
+        },
         ...createTextureUniforms(config),
       },
       transparent: true,
@@ -218,6 +226,10 @@ export class GridScene {
       this.material.uniforms.uWaveMode.value = GridScene.waveModeValue(
         config.sceneParams.wavePattern as string
       );
+    }
+    if (config.sceneParams?.particleShape !== undefined) {
+      this.material.uniforms.uParticleShape.value =
+        PARTICLE_SHAPE_INDEX[config.sceneParams.particleShape as string] ?? 0;
     }
     this.config = { ...this.config, ...config };
   }
@@ -278,6 +290,7 @@ const METADATA: SceneRegistration = {
       ],
       default: 'diagonal',
     },
+    PARTICLE_SHAPE_PARAM,
   ],
 };
 

--- a/src/components/visualizer/scenes/grid-scene.ts
+++ b/src/components/visualizer/scenes/grid-scene.ts
@@ -6,9 +6,10 @@ import {
   TEXTURE_SAMPLE_FN,
   PARTICLE_SHAPE_UNIFORM,
   PARTICLE_SHAPE_FN,
-  PARTICLE_SHAPE_INDEX,
   PARTICLE_SHAPE_PARAM,
   createTextureUniforms,
+  createParticleShapeUniform,
+  updateParticleShape,
   applyTextureTransform,
 } from './shader-chunks';
 import type { SceneRegistration, TextureTransform } from './types';
@@ -178,10 +179,7 @@ export class GridScene {
         uPrimary: { value: new THREE.Color(palette.primary) },
         uSecondary: { value: new THREE.Color(palette.secondary) },
         uAccent: { value: new THREE.Color(palette.accent) },
-        uParticleShape: {
-          value:
-            PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
-        },
+        ...createParticleShapeUniform(config),
         ...createTextureUniforms(config),
       },
       transparent: true,
@@ -227,10 +225,7 @@ export class GridScene {
         config.sceneParams.wavePattern as string
       );
     }
-    if (config.sceneParams?.particleShape !== undefined) {
-      this.material.uniforms.uParticleShape.value =
-        PARTICLE_SHAPE_INDEX[config.sceneParams.particleShape as string] ?? 0;
-    }
+    if (config.sceneParams) updateParticleShape(this.material, config.sceneParams);
     this.config = { ...this.config, ...config };
   }
 

--- a/src/components/visualizer/scenes/index.ts
+++ b/src/components/visualizer/scenes/index.ts
@@ -20,6 +20,7 @@ import './orb-scene';
 import './particle-scene';
 import './rings-scene';
 import './sacredgeo-scene';
+import './silhouette-scene';
 import './starburst-classic-scene';
 import './starburst-scene';
 import './starburst-sharp-scene';

--- a/src/components/visualizer/scenes/lattice-scene.ts
+++ b/src/components/visualizer/scenes/lattice-scene.ts
@@ -6,9 +6,10 @@ import {
   TEXTURE_SAMPLE_FN,
   PARTICLE_SHAPE_UNIFORM,
   PARTICLE_SHAPE_FN,
-  PARTICLE_SHAPE_INDEX,
   PARTICLE_SHAPE_PARAM,
   createTextureUniforms,
+  createParticleShapeUniform,
+  updateParticleShape,
   applyTextureTransform,
 } from './shader-chunks';
 import type { SceneRegistration, TextureTransform } from './types';
@@ -18,7 +19,7 @@ export class LatticeScene {
   private material: THREE.ShaderMaterial;
   private clock: THREE.Clock;
 
-  private static BASE_POINT_SIZE = 4.0;
+  private static BASE_POINT_SIZE = 3.0;
 
   private static VERTEX = `
     attribute float aPhase;
@@ -38,7 +39,7 @@ export class LatticeScene {
       vDist = length(position);
 
       // Size pulsing from center outward — dramatic with bloom
-      float pulse = 1.0 + uBass * 0.8 * sin(uTime * uSpeed + vDist * 0.8);
+      float pulse = 1.0 + uBass * 0.5 * sin(uTime * uSpeed + vDist * 0.8);
       float size = uPointSize * max(pulse, 0.3);
 
       vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
@@ -55,6 +56,7 @@ export class LatticeScene {
     uniform float uTime;
     uniform float uSpeed;
     uniform float uHigh;
+    uniform float uBrightness;
     uniform vec3 uPrimary;
     uniform vec3 uSecondary;
     uniform vec3 uAccent;
@@ -74,33 +76,37 @@ export class LatticeScene {
       vec2 center = gl_PointCoord - 0.5;
       float dist = length(center);
 
-      float shapeAlpha = particleShapeAlpha(gl_PointCoord, uParticleShape);
-      if (shapeAlpha < 0.01) discard;
+      float alpha;
+      vec4 texSample = vec4(1.0);
+      if (uHasTexture) {
+        texSample = sampleTransformedTexture(vec2(gl_PointCoord.x, 1.0 - gl_PointCoord.y));
+        alpha = texSample.a * 0.7;
+        if (alpha < 0.01) discard;
+      } else {
+        alpha = particleShapeAlpha(gl_PointCoord, uParticleShape) * 0.7;
+        if (alpha < 0.01) discard;
+      }
 
-      float glow = exp(-dist * 4.0);
+      float glow = exp(-dist * 6.0);
 
       // HSL hue cycling based on lattice position + time
       float hue = vPhase + uTime * uSpeed * (0.05 + uHigh * 0.2);
       hue = fract(hue);
 
       // Map through palette tints
-      vec3 hslColor = hsl2rgb(hue, 0.7, 0.5 + uHigh * 0.2);
+      vec3 hslColor = hsl2rgb(hue, 0.55, 0.32 + uHigh * 0.2);
       vec3 color = mix(hslColor, uPrimary, 0.3);
 
-      // Bright accent center
-      color = mix(color, uAccent, glow * 0.6);
+      // Accent center glow
+      color = mix(color, uAccent, glow * 0.35);
 
-      // Brightness from highs
-      float brightness = 0.7 + uHigh * 0.8;
+      // Brightness from highs + user control
+      float brightness = (0.35 + uHigh * 0.7) * uBrightness;
       color *= brightness;
 
-      // Texture overlay at point coord
-      if (uHasTexture) {
-        vec4 texSample = sampleTransformedTexture(vec2(gl_PointCoord.x, 1.0 - gl_PointCoord.y));
-        color = mix(color, texSample.rgb, texSample.a);
-      }
+      // Subtle texture tint — 40% influence, preserves lattice color dominance
+      if (uHasTexture) color *= mix(vec3(1.0), texSample.rgb, 0.4);
 
-      float alpha = shapeAlpha * 0.85;
       gl_FragColor = vec4(color, alpha);
     }
   `;
@@ -149,13 +155,11 @@ export class LatticeScene {
         uBass: { value: 0 },
         uHigh: { value: 0 },
         uPointSize: { value: LatticeScene.BASE_POINT_SIZE },
+        uBrightness: { value: (config.sceneParams?.brightness as number) ?? 1.0 },
         uPrimary: { value: new THREE.Color(palette.primary) },
         uSecondary: { value: new THREE.Color(palette.secondary) },
         uAccent: { value: new THREE.Color(palette.accent) },
-        uParticleShape: {
-          value:
-            PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
-        },
+        ...createParticleShapeUniform(config),
         ...createTextureUniforms(config),
       },
       transparent: true,
@@ -193,10 +197,10 @@ export class LatticeScene {
       this.material.uniforms.uPointSize.value = LatticeScene.BASE_POINT_SIZE * config.textureScale;
       this.material.uniforms.uTextureScale.value = config.textureScale;
     }
-    if (config.sceneParams?.particleShape !== undefined) {
-      this.material.uniforms.uParticleShape.value =
-        PARTICLE_SHAPE_INDEX[config.sceneParams.particleShape as string] ?? 0;
+    if (config.sceneParams?.brightness !== undefined) {
+      this.material.uniforms.uBrightness.value = config.sceneParams.brightness as number;
     }
+    if (config.sceneParams) updateParticleShape(this.material, config.sceneParams);
     this.config = { ...this.config, ...config };
   }
 
@@ -233,6 +237,15 @@ const METADATA: SceneRegistration = {
       max: 1,
       step: 0.05,
       default: 0.5,
+    },
+    {
+      key: 'brightness',
+      label: 'Brightness',
+      type: 'slider',
+      min: 0.05,
+      max: 4.0,
+      step: 0.05,
+      default: 1.0,
     },
     PARTICLE_SHAPE_PARAM,
   ],

--- a/src/components/visualizer/scenes/lattice-scene.ts
+++ b/src/components/visualizer/scenes/lattice-scene.ts
@@ -4,6 +4,10 @@ import { registerScene } from './scene-registry';
 import {
   TEXTURE_UNIFORMS,
   TEXTURE_SAMPLE_FN,
+  PARTICLE_SHAPE_UNIFORM,
+  PARTICLE_SHAPE_FN,
+  PARTICLE_SHAPE_INDEX,
+  PARTICLE_SHAPE_PARAM,
   createTextureUniforms,
   applyTextureTransform,
 } from './shader-chunks';
@@ -46,6 +50,8 @@ export class LatticeScene {
   private static FRAGMENT = `
     ${TEXTURE_UNIFORMS}
     ${TEXTURE_SAMPLE_FN}
+    ${PARTICLE_SHAPE_UNIFORM}
+    ${PARTICLE_SHAPE_FN}
     uniform float uTime;
     uniform float uSpeed;
     uniform float uHigh;
@@ -65,12 +71,12 @@ export class LatticeScene {
     }
 
     void main() {
-      // Circular point sprite with soft glow edges
       vec2 center = gl_PointCoord - 0.5;
       float dist = length(center);
-      if (dist > 0.5) discard;
 
-      float softEdge = 1.0 - smoothstep(0.2, 0.5, dist);
+      float shapeAlpha = particleShapeAlpha(gl_PointCoord, uParticleShape);
+      if (shapeAlpha < 0.01) discard;
+
       float glow = exp(-dist * 4.0);
 
       // HSL hue cycling based on lattice position + time
@@ -94,7 +100,7 @@ export class LatticeScene {
         color = mix(color, texSample.rgb, texSample.a);
       }
 
-      float alpha = softEdge * 0.85;
+      float alpha = shapeAlpha * 0.85;
       gl_FragColor = vec4(color, alpha);
     }
   `;
@@ -146,6 +152,10 @@ export class LatticeScene {
         uPrimary: { value: new THREE.Color(palette.primary) },
         uSecondary: { value: new THREE.Color(palette.secondary) },
         uAccent: { value: new THREE.Color(palette.accent) },
+        uParticleShape: {
+          value:
+            PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
+        },
         ...createTextureUniforms(config),
       },
       transparent: true,
@@ -182,6 +192,10 @@ export class LatticeScene {
     if (config.textureScale !== undefined) {
       this.material.uniforms.uPointSize.value = LatticeScene.BASE_POINT_SIZE * config.textureScale;
       this.material.uniforms.uTextureScale.value = config.textureScale;
+    }
+    if (config.sceneParams?.particleShape !== undefined) {
+      this.material.uniforms.uParticleShape.value =
+        PARTICLE_SHAPE_INDEX[config.sceneParams.particleShape as string] ?? 0;
     }
     this.config = { ...this.config, ...config };
   }
@@ -220,6 +234,7 @@ const METADATA: SceneRegistration = {
       step: 0.05,
       default: 0.5,
     },
+    PARTICLE_SHAPE_PARAM,
   ],
 };
 

--- a/src/components/visualizer/scenes/nebula-scene.ts
+++ b/src/components/visualizer/scenes/nebula-scene.ts
@@ -6,9 +6,10 @@ import {
   TEXTURE_SAMPLE_FN,
   PARTICLE_SHAPE_UNIFORM,
   PARTICLE_SHAPE_FN,
-  PARTICLE_SHAPE_INDEX,
   PARTICLE_SHAPE_PARAM,
   createTextureUniforms,
+  createParticleShapeUniform,
+  updateParticleShape,
   applyTextureTransform,
 } from './shader-chunks';
 import type { SceneRegistration, TextureTransform } from './types';
@@ -130,10 +131,7 @@ export class NebulaScene {
         uPrimary: { value: new THREE.Color(palette.primary) },
         uSecondary: { value: new THREE.Color(palette.secondary) },
         uAccent: { value: new THREE.Color(palette.accent) },
-        uParticleShape: {
-          value:
-            PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
-        },
+        ...createParticleShapeUniform(config),
         ...createTextureUniforms(config),
       },
       transparent: true,
@@ -169,10 +167,7 @@ export class NebulaScene {
     if (config.textureScale !== undefined) {
       this.material.uniforms.uTextureScale.value = config.textureScale;
     }
-    if (config.sceneParams?.particleShape !== undefined) {
-      this.material.uniforms.uParticleShape.value =
-        PARTICLE_SHAPE_INDEX[config.sceneParams.particleShape as string] ?? 0;
-    }
+    if (config.sceneParams) updateParticleShape(this.material, config.sceneParams);
     this.config = { ...this.config, ...config };
   }
 

--- a/src/components/visualizer/scenes/nebula-scene.ts
+++ b/src/components/visualizer/scenes/nebula-scene.ts
@@ -4,6 +4,10 @@ import { registerScene } from './scene-registry';
 import {
   TEXTURE_UNIFORMS,
   TEXTURE_SAMPLE_FN,
+  PARTICLE_SHAPE_UNIFORM,
+  PARTICLE_SHAPE_FN,
+  PARTICLE_SHAPE_INDEX,
+  PARTICLE_SHAPE_PARAM,
   createTextureUniforms,
   applyTextureTransform,
 } from './shader-chunks';
@@ -47,6 +51,8 @@ export class NebulaScene {
   private static FRAGMENT = `
     ${TEXTURE_UNIFORMS}
     ${TEXTURE_SAMPLE_FN}
+    ${PARTICLE_SHAPE_UNIFORM}
+    ${PARTICLE_SHAPE_FN}
     uniform vec3 uPrimary;
     uniform vec3 uSecondary;
     uniform vec3 uAccent;
@@ -67,8 +73,8 @@ export class NebulaScene {
         alpha = texSample.a;
         if (alpha < 0.01) discard;
       } else {
-        if (d > 0.5) discard;
-        alpha = smoothstep(0.5, 0.0, d) * 0.6;
+        alpha = particleShapeAlpha(gl_PointCoord, uParticleShape) * 0.6;
+        if (alpha < 0.01) discard;
       }
 
       float colorMix = sin(vPhase * 6.28 + uTime * uSpeed * 0.2 + uMid * 2.0) * 0.5 + 0.5;
@@ -124,6 +130,10 @@ export class NebulaScene {
         uPrimary: { value: new THREE.Color(palette.primary) },
         uSecondary: { value: new THREE.Color(palette.secondary) },
         uAccent: { value: new THREE.Color(palette.accent) },
+        uParticleShape: {
+          value:
+            PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
+        },
         ...createTextureUniforms(config),
       },
       transparent: true,
@@ -158,6 +168,10 @@ export class NebulaScene {
     }
     if (config.textureScale !== undefined) {
       this.material.uniforms.uTextureScale.value = config.textureScale;
+    }
+    if (config.sceneParams?.particleShape !== undefined) {
+      this.material.uniforms.uParticleShape.value =
+        PARTICLE_SHAPE_INDEX[config.sceneParams.particleShape as string] ?? 0;
     }
     this.config = { ...this.config, ...config };
   }
@@ -195,6 +209,7 @@ const METADATA: SceneRegistration = {
       step: 0.05,
       default: 0.5,
     },
+    PARTICLE_SHAPE_PARAM,
   ],
 };
 

--- a/src/components/visualizer/scenes/shader-chunks.ts
+++ b/src/components/visualizer/scenes/shader-chunks.ts
@@ -41,6 +41,76 @@ export const TEXTURE_SAMPLE_FN = `
   }
 `;
 
+// ── Particle shape GLSL ─────────────────────────────────────────────────────
+
+/** Uniform declaration for particle shape (int: 0=circle,1=star,2=diamond,3=ring,4=sparkle). */
+export const PARTICLE_SHAPE_UNIFORM = `
+  uniform int uParticleShape;
+`;
+
+/**
+ * GLSL function returning alpha for the current gl_PointCoord given a shape index.
+ * Shapes: 0=circle (soft glow), 1=star, 2=diamond, 3=ring, 4=sparkle.
+ */
+export const PARTICLE_SHAPE_FN = `
+  float particleShapeAlpha(vec2 coord, int shape) {
+    vec2 c = coord - 0.5;
+    float d = length(c);
+    if (shape == 1) {
+      // Star — 5-pointed via polar modulation
+      float angle = atan(c.y, c.x);
+      float star = cos(angle * 2.5); // 5-fold symmetry
+      float edge = 0.25 + star * 0.18;
+      return smoothstep(edge + 0.04, edge - 0.04, d);
+    }
+    if (shape == 2) {
+      // Diamond — L1 norm
+      float dd = abs(c.x) + abs(c.y);
+      return smoothstep(0.5, 0.3, dd);
+    }
+    if (shape == 3) {
+      // Ring — hollow circle
+      float ring = abs(d - 0.3);
+      return smoothstep(0.12, 0.0, ring);
+    }
+    if (shape == 4) {
+      // Sparkle — 4-pointed cross-star
+      float angle = atan(c.y, c.x);
+      float spike = pow(abs(cos(angle * 2.0)), 8.0);
+      float edge = mix(0.08, 0.45, spike);
+      return smoothstep(edge + 0.03, edge - 0.03, d);
+    }
+    // 0 = Circle — soft radial glow (default)
+    return smoothstep(0.5, 0.0, d);
+  }
+`;
+
+/** Map ParticleShape string → int for the uParticleShape uniform. */
+export const PARTICLE_SHAPE_INDEX: Record<string, number> = {
+  circle: 0,
+  star: 1,
+  diamond: 2,
+  ring: 3,
+  sparkle: 4,
+};
+
+/** The particleShape SceneParamDef shared across all particle scenes. */
+export const PARTICLE_SHAPE_PARAM = {
+  key: 'particleShape',
+  label: 'Particle Shape',
+  type: 'select' as const,
+  default: 'circle',
+  options: [
+    { label: 'Circle', value: 'circle' },
+    { label: 'Star', value: 'star' },
+    { label: 'Diamond', value: 'diamond' },
+    { label: 'Ring', value: 'ring' },
+    { label: 'Sparkle', value: 'sparkle' },
+  ],
+};
+
+// ── Texture uniforms ────────────────────────────────────────────────────────
+
 /** Standard texture uniform initial values for ShaderMaterial constructors. */
 export function createTextureUniforms(config: { textureScale?: number; textureOpacity?: number }) {
   return {

--- a/src/components/visualizer/scenes/shader-chunks.ts
+++ b/src/components/visualizer/scenes/shader-chunks.ts
@@ -57,9 +57,9 @@ export const PARTICLE_SHAPE_FN = `
     vec2 c = coord - 0.5;
     float d = length(c);
     if (shape == 1) {
-      // Star — 5-pointed via polar modulation
+      // Star — cos(angle * 5/2) gives 5 peaks over [0, 2pi]
       float angle = atan(c.y, c.x);
-      float star = cos(angle * 2.5); // 5-fold symmetry
+      float star = cos(angle * 2.5);
       float edge = 0.25 + star * 0.18;
       return smoothstep(edge + 0.04, edge - 0.04, d);
     }
@@ -108,6 +108,26 @@ export const PARTICLE_SHAPE_PARAM = {
     { label: 'Sparkle', value: 'sparkle' },
   ],
 };
+
+/** Create uParticleShape uniform value from config. */
+export function createParticleShapeUniform(config: { sceneParams?: Record<string, unknown> }) {
+  return {
+    uParticleShape: {
+      value: PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
+    },
+  };
+}
+
+/** Update uParticleShape uniform on a ShaderMaterial from sceneParams. */
+export function updateParticleShape(
+  material: THREE.ShaderMaterial,
+  sceneParams: Record<string, unknown>
+): void {
+  if (sceneParams.particleShape !== undefined) {
+    material.uniforms.uParticleShape.value =
+      PARTICLE_SHAPE_INDEX[sceneParams.particleShape as string] ?? 0;
+  }
+}
 
 // ── Texture uniforms ────────────────────────────────────────────────────────
 

--- a/src/components/visualizer/scenes/shader-chunks.ts
+++ b/src/components/visualizer/scenes/shader-chunks.ts
@@ -57,10 +57,10 @@ export const PARTICLE_SHAPE_FN = `
     vec2 c = coord - 0.5;
     float d = length(c);
     if (shape == 1) {
-      // Star — cos(angle * 5/2) gives 5 peaks over [0, 2pi]
+      // Star — cos(5*angle) gives 5 closed peaks over [0, 2pi]
       float angle = atan(c.y, c.x);
-      float star = cos(angle * 2.5);
-      float edge = 0.25 + star * 0.18;
+      float star = cos(angle * 5.0);
+      float edge = 0.25 + star * 0.15;
       return smoothstep(edge + 0.04, edge - 0.04, d);
     }
     if (shape == 2) {
@@ -80,6 +80,10 @@ export const PARTICLE_SHAPE_FN = `
       float edge = mix(0.08, 0.45, spike);
       return smoothstep(edge + 0.03, edge - 0.03, d);
     }
+    if (shape == 5) {
+      // Streak — elongated vertical ellipse for warp/flythrough
+      return smoothstep(0.5, 0.0, abs(c.x) * 3.0) * smoothstep(0.5, 0.0, d);
+    }
     // 0 = Circle — soft radial glow (default)
     return smoothstep(0.5, 0.0, d);
   }
@@ -92,6 +96,7 @@ export const PARTICLE_SHAPE_INDEX: Record<string, number> = {
   diamond: 2,
   ring: 3,
   sparkle: 4,
+  streak: 5,
 };
 
 /** The particleShape SceneParamDef shared across all particle scenes. */
@@ -106,6 +111,7 @@ export const PARTICLE_SHAPE_PARAM = {
     { label: 'Diamond', value: 'diamond' },
     { label: 'Ring', value: 'ring' },
     { label: 'Sparkle', value: 'sparkle' },
+    { label: 'Streak', value: 'streak' },
   ],
 };
 

--- a/src/components/visualizer/scenes/silhouette-scene.ts
+++ b/src/components/visualizer/scenes/silhouette-scene.ts
@@ -26,6 +26,7 @@ const FRAGMENT_SHADER =
   uniform float uMid;
   uniform float uHigh;
   uniform float uSpeed;
+  uniform float uTunnelSpeed;
   uniform float uGlowDensity;
   uniform float uShapeScale;
   uniform float uEdgeSharpness;
@@ -71,7 +72,7 @@ const FRAGMENT_SHADER =
 
   void main() {
     vec2 uv = vUv - 0.5;
-    float t = uTime * uSpeed;
+    float t = uTime * uSpeed * uTunnelSpeed;
 
     // Ripple offset per step — mid-reactive
     float ripple = 0.08 + uMid * 0.12;
@@ -86,7 +87,11 @@ const FRAGMENT_SHADER =
     float totalT = 0.0;
     float ac = 0.0; // accumulated glow
 
+    // 99-step raymarch with glow accumulation — GPU-intensive due to
+    // per-step texture2D when a texture is loaded. Early-out when the
+    // ray has marched past the useful tiled domain.
     for (int i = 0; i < 99; i++) {
+      if (totalT > 20.0) break;
       vec3 pos = ro + ray * totalT;
       // Domain repetition — tile space [-2,2]
       pos = mod(pos - 2.0, 4.0) - 2.0;
@@ -111,7 +116,7 @@ const FRAGMENT_SHADER =
     vec3 col1 = mix(uPrimary, uSecondary, colorShift);
     vec3 col2 = mix(uSecondary, uAccent, fract(colorShift + 0.33));
 
-    vec3 color = mix(col1, col2, sin(intensity * 3.14) * 0.5 + 0.5) * intensity;
+    vec3 color = mix(col1, col2, sin(intensity * 3.14159) * 0.5 + 0.5) * intensity;
 
     // Accent highlights on bright areas
     color += uAccent * pow(intensity, 3.0) * 0.5;
@@ -149,6 +154,7 @@ export class SilhouetteScene {
         uMid: { value: 0 },
         uHigh: { value: 0 },
         uSpeed: { value: config.animationSpeed },
+        uTunnelSpeed: { value: (sp.tunnelSpeed as number) ?? 1.0 },
         uGlowDensity: { value: (sp.glowDensity as number) ?? 1.0 },
         uShapeScale: { value: (sp.shapeScale as number) ?? 1.0 },
         uEdgeSharpness: { value: (sp.edgeSharpness as number) ?? 2.0 },
@@ -187,6 +193,7 @@ export class SilhouetteScene {
     }
     if (config.sceneParams) {
       const sp = config.sceneParams;
+      if (sp.tunnelSpeed !== undefined) this.material.uniforms.uTunnelSpeed.value = sp.tunnelSpeed;
       if (sp.glowDensity !== undefined) this.material.uniforms.uGlowDensity.value = sp.glowDensity;
       if (sp.shapeScale !== undefined) this.material.uniforms.uShapeScale.value = sp.shapeScale;
       if (sp.edgeSharpness !== undefined)
@@ -218,7 +225,9 @@ const METADATA: SceneRegistration = {
   category: 'psychedelic',
   audioDescription:
     'Bass scales shape and pulses glow, mids control tunnel ripple, highs shift color',
-  features: ['textureScale', 'textureOpacity', 'textureAnimation', 'textureMotion'],
+  // Note: textureOpacity omitted — opacity only affects the color overlay, not the
+  // SDF geometry which samples texture alpha directly via texture2D().
+  features: ['textureScale', 'textureAnimation', 'textureMotion'],
   cameraHint: 'small-plane',
   params: [
     {

--- a/src/components/visualizer/scenes/silhouette-scene.ts
+++ b/src/components/visualizer/scenes/silhouette-scene.ts
@@ -1,0 +1,263 @@
+import * as THREE from 'three';
+import type { VisualizerConfig } from '@/types/visualizer';
+import { registerScene } from './scene-registry';
+import type { SceneRegistration, TextureTransform } from './types';
+import {
+  TEXTURE_UNIFORMS,
+  TEXTURE_SAMPLE_FN,
+  createTextureUniforms,
+  applyTextureTransform,
+} from './shader-chunks';
+
+const VERTEX_SHADER = `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const FRAGMENT_SHADER =
+  TEXTURE_UNIFORMS +
+  TEXTURE_SAMPLE_FN +
+  `
+  uniform float uTime;
+  uniform float uBass;
+  uniform float uMid;
+  uniform float uHigh;
+  uniform float uSpeed;
+  uniform float uGlowDensity;
+  uniform float uShapeScale;
+  uniform float uEdgeSharpness;
+  uniform vec3 uPrimary;
+  uniform vec3 uSecondary;
+  uniform vec3 uAccent;
+  varying vec2 vUv;
+
+  mat2 rot(float a) {
+    float c = cos(a), s = sin(a);
+    return mat2(c, -s, s, c);
+  }
+
+  // Fallback shape: diamond SDF
+  float fallbackShape(vec3 pos, float gTime) {
+    float pulse = sin(gTime * 0.4);
+    pos.xy *= rot(gTime * 0.2);
+    // Diamond: |x| + |y| - size
+    float d = (abs(pos.x) + abs(pos.y)) - (0.8 + pulse * 0.3);
+    return d;
+  }
+
+  // Texture-based pseudo-SDF: sample alpha, convert to edge distance
+  float textureSDF(vec2 tilePos, float gTime) {
+    // Map domain-repeated coords [-2,2] to [0,1] UV space
+    vec2 uv = (tilePos + 2.0) / 4.0;
+
+    // Animate: gentle rotation over time, bass-reactive scale
+    float angle = gTime * 0.1;
+    float sc = 1.0 / (uShapeScale * (1.0 + uBass * 0.3));
+    uv -= 0.5;
+    float c = cos(angle), s = sin(angle);
+    uv = vec2(c * uv.x - s * uv.y, s * uv.x + c * uv.y) * sc;
+    uv += 0.5;
+
+    // Sample alpha — clamp OOB to 0
+    float inB = step(0.0, uv.x) * step(uv.x, 1.0) * step(0.0, uv.y) * step(uv.y, 1.0);
+    float alpha = texture2D(uTexture, uv).a * inB;
+
+    // Edge distance: 0 at boundary, grows toward interior/exterior
+    return abs(alpha - 0.5) * uEdgeSharpness;
+  }
+
+  void main() {
+    vec2 uv = vUv - 0.5;
+    float t = uTime * uSpeed;
+
+    // Ripple offset per step — mid-reactive
+    float ripple = 0.08 + uMid * 0.12;
+
+    // Glow exponent — higher = tighter glow lines
+    float glowExp = 8.0 * uGlowDensity;
+
+    // Ray origin flies forward
+    vec3 ro = vec3(uv, t);
+    vec3 ray = normalize(vec3(uv, 1.0));
+
+    float totalT = 0.0;
+    float ac = 0.0; // accumulated glow
+
+    for (int i = 0; i < 99; i++) {
+      vec3 pos = ro + ray * totalT;
+      // Domain repetition — tile space [-2,2]
+      pos = mod(pos - 2.0, 4.0) - 2.0;
+      float gTime = t - float(i) * ripple;
+
+      float d;
+      if (uHasTexture) {
+        d = textureSDF(pos.xy, gTime);
+      } else {
+        d = fallbackShape(pos, gTime);
+      }
+      d = max(abs(d), 0.01);
+      ac += exp(-d * glowExp);
+      totalT += d * 0.55;
+    }
+
+    // Color from accumulated glow
+    float intensity = ac * 0.015;
+
+    // Bass-reactive color mixing
+    float colorShift = sin(t * 0.3) * 0.5 + 0.5 + uHigh * 0.5;
+    vec3 col1 = mix(uPrimary, uSecondary, colorShift);
+    vec3 col2 = mix(uSecondary, uAccent, fract(colorShift + 0.33));
+
+    vec3 color = mix(col1, col2, sin(intensity * 3.14) * 0.5 + 0.5) * intensity;
+
+    // Accent highlights on bright areas
+    color += uAccent * pow(intensity, 3.0) * 0.5;
+
+    // Standard texture overlay (separate from SDF sampling)
+    if (uHasTexture) {
+      vec4 tex = sampleTransformedTexture((vUv - 0.5) / uTextureScale + 0.5);
+      color = mix(color, tex.rgb, tex.a * 0.3);
+    }
+
+    gl_FragColor = vec4(color, 1.0);
+  }
+`;
+
+export class SilhouetteScene {
+  private mesh: THREE.Mesh;
+  private material: THREE.ShaderMaterial;
+  private clock: THREE.Clock;
+
+  constructor(
+    private scene: THREE.Scene,
+    private config: VisualizerConfig
+  ) {
+    this.clock = new THREE.Clock();
+    const palette = config.colorPalette;
+    const sp = config.sceneParams ?? {};
+
+    const geometry = new THREE.PlaneGeometry(12, 12);
+    this.material = new THREE.ShaderMaterial({
+      vertexShader: VERTEX_SHADER,
+      fragmentShader: FRAGMENT_SHADER,
+      uniforms: {
+        uTime: { value: 0 },
+        uBass: { value: 0 },
+        uMid: { value: 0 },
+        uHigh: { value: 0 },
+        uSpeed: { value: config.animationSpeed },
+        uGlowDensity: { value: (sp.glowDensity as number) ?? 1.0 },
+        uShapeScale: { value: (sp.shapeScale as number) ?? 1.0 },
+        uEdgeSharpness: { value: (sp.edgeSharpness as number) ?? 2.0 },
+        uPrimary: { value: new THREE.Color(palette.primary) },
+        uSecondary: { value: new THREE.Color(palette.secondary) },
+        uAccent: { value: new THREE.Color(palette.accent) },
+        ...createTextureUniforms(config),
+      },
+    });
+
+    this.mesh = new THREE.Mesh(geometry, this.material);
+    this.mesh.position.z = -2;
+    this.scene.add(this.mesh);
+  }
+
+  update(bass: number, mid: number, high: number): void {
+    const time = this.clock.getElapsedTime();
+    const r = this.config.audioReactivity;
+    this.material.uniforms.uTime.value = time;
+    this.material.uniforms.uBass.value = bass * r;
+    this.material.uniforms.uMid.value = mid * r;
+    this.material.uniforms.uHigh.value = high * r;
+  }
+
+  updateConfig(config: Partial<VisualizerConfig>): void {
+    if (config.colorPalette) {
+      this.material.uniforms.uPrimary.value.set(config.colorPalette.primary);
+      this.material.uniforms.uSecondary.value.set(config.colorPalette.secondary);
+      this.material.uniforms.uAccent.value.set(config.colorPalette.accent);
+    }
+    if (config.animationSpeed !== undefined) {
+      this.material.uniforms.uSpeed.value = config.animationSpeed;
+    }
+    if (config.textureScale !== undefined) {
+      this.material.uniforms.uTextureScale.value = config.textureScale;
+    }
+    if (config.sceneParams) {
+      const sp = config.sceneParams;
+      if (sp.glowDensity !== undefined) this.material.uniforms.uGlowDensity.value = sp.glowDensity;
+      if (sp.shapeScale !== undefined) this.material.uniforms.uShapeScale.value = sp.shapeScale;
+      if (sp.edgeSharpness !== undefined)
+        this.material.uniforms.uEdgeSharpness.value = sp.edgeSharpness;
+    }
+    this.config = { ...this.config, ...config };
+  }
+
+  setTexture(texture: THREE.Texture | null): void {
+    this.material.uniforms.uTexture.value = texture;
+    this.material.uniforms.uHasTexture.value = texture !== null;
+  }
+
+  setTextureTransform(transform: TextureTransform): void {
+    applyTextureTransform(this.material, transform);
+  }
+
+  dispose(): void {
+    this.scene.remove(this.mesh);
+    this.mesh.geometry.dispose();
+    this.material.dispose();
+  }
+}
+
+const METADATA: SceneRegistration = {
+  id: 'silhouette',
+  name: 'Silhouette',
+  description: 'Raymarched tunnel using your uploaded texture outline as the repeating shape.',
+  category: 'psychedelic',
+  audioDescription:
+    'Bass scales shape and pulses glow, mids control tunnel ripple, highs shift color',
+  features: ['textureScale', 'textureOpacity', 'textureAnimation', 'textureMotion'],
+  cameraHint: 'small-plane',
+  params: [
+    {
+      key: 'glowDensity',
+      label: 'Glow Density',
+      type: 'slider',
+      min: 0.3,
+      max: 2.0,
+      step: 0.1,
+      default: 1.0,
+    },
+    {
+      key: 'tunnelSpeed',
+      label: 'Tunnel Speed',
+      type: 'slider',
+      min: 0.2,
+      max: 2.0,
+      step: 0.1,
+      default: 1.0,
+    },
+    {
+      key: 'shapeScale',
+      label: 'Shape Scale',
+      type: 'slider',
+      min: 0.3,
+      max: 3.0,
+      step: 0.1,
+      default: 1.0,
+    },
+    {
+      key: 'edgeSharpness',
+      label: 'Edge Width',
+      type: 'slider',
+      min: 0.5,
+      max: 4.0,
+      step: 0.1,
+      default: 2.0,
+    },
+  ],
+};
+
+registerScene('silhouette', (scene, config) => new SilhouetteScene(scene, config), METADATA);

--- a/src/components/visualizer/scenes/starfield-scene.ts
+++ b/src/components/visualizer/scenes/starfield-scene.ts
@@ -6,9 +6,10 @@ import {
   TEXTURE_SAMPLE_FN,
   PARTICLE_SHAPE_UNIFORM,
   PARTICLE_SHAPE_FN,
-  PARTICLE_SHAPE_INDEX,
   PARTICLE_SHAPE_PARAM,
   createTextureUniforms,
+  createParticleShapeUniform,
+  updateParticleShape,
   applyTextureTransform,
 } from './shader-chunks';
 import type { SceneRegistration, TextureTransform } from './types';
@@ -126,10 +127,7 @@ export class StarfieldScene {
         uPrimary: { value: new THREE.Color(palette.primary) },
         uSecondary: { value: new THREE.Color(palette.secondary) },
         uAccent: { value: new THREE.Color(palette.accent) },
-        uParticleShape: {
-          value:
-            PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
-        },
+        ...createParticleShapeUniform(config),
         ...createTextureUniforms(config),
       },
       transparent: true,
@@ -161,10 +159,7 @@ export class StarfieldScene {
     if (config.textureScale !== undefined) {
       this.material.uniforms.uTextureScale.value = config.textureScale;
     }
-    if (config.sceneParams?.particleShape !== undefined) {
-      this.material.uniforms.uParticleShape.value =
-        PARTICLE_SHAPE_INDEX[config.sceneParams.particleShape as string] ?? 0;
-    }
+    if (config.sceneParams) updateParticleShape(this.material, config.sceneParams);
     this.config = { ...this.config, ...config };
   }
 

--- a/src/components/visualizer/scenes/starfield-scene.ts
+++ b/src/components/visualizer/scenes/starfield-scene.ts
@@ -4,6 +4,10 @@ import { registerScene } from './scene-registry';
 import {
   TEXTURE_UNIFORMS,
   TEXTURE_SAMPLE_FN,
+  PARTICLE_SHAPE_UNIFORM,
+  PARTICLE_SHAPE_FN,
+  PARTICLE_SHAPE_INDEX,
+  PARTICLE_SHAPE_PARAM,
   createTextureUniforms,
   applyTextureTransform,
 } from './shader-chunks';
@@ -51,6 +55,8 @@ export class StarfieldScene {
   private static FRAGMENT = `
     ${TEXTURE_UNIFORMS}
     ${TEXTURE_SAMPLE_FN}
+    ${PARTICLE_SHAPE_UNIFORM}
+    ${PARTICLE_SHAPE_FN}
     uniform vec3 uPrimary;
     uniform vec3 uSecondary;
     uniform vec3 uAccent;
@@ -71,9 +77,8 @@ export class StarfieldScene {
         alpha = texSample.a * (0.6 + closeness * 0.4);
         if (alpha < 0.01) discard;
       } else {
-        if (d > 0.5) discard;
-        float streak = smoothstep(0.5, 0.0, abs(center.x) * 3.0) * smoothstep(0.5, 0.0, d);
-        alpha = streak * (0.6 + closeness * 0.4);
+        alpha = particleShapeAlpha(gl_PointCoord, uParticleShape) * (0.6 + closeness * 0.4);
+        if (alpha < 0.01) discard;
       }
 
       vec3 color = mix(uSecondary, uPrimary, closeness);
@@ -121,6 +126,10 @@ export class StarfieldScene {
         uPrimary: { value: new THREE.Color(palette.primary) },
         uSecondary: { value: new THREE.Color(palette.secondary) },
         uAccent: { value: new THREE.Color(palette.accent) },
+        uParticleShape: {
+          value:
+            PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
+        },
         ...createTextureUniforms(config),
       },
       transparent: true,
@@ -151,6 +160,10 @@ export class StarfieldScene {
     }
     if (config.textureScale !== undefined) {
       this.material.uniforms.uTextureScale.value = config.textureScale;
+    }
+    if (config.sceneParams?.particleShape !== undefined) {
+      this.material.uniforms.uParticleShape.value =
+        PARTICLE_SHAPE_INDEX[config.sceneParams.particleShape as string] ?? 0;
     }
     this.config = { ...this.config, ...config };
   }
@@ -188,6 +201,7 @@ const METADATA: SceneRegistration = {
       step: 0.05,
       default: 0.5,
     },
+    PARTICLE_SHAPE_PARAM,
   ],
 };
 

--- a/src/components/visualizer/scenes/starfield-scene.ts
+++ b/src/components/visualizer/scenes/starfield-scene.ts
@@ -196,7 +196,7 @@ const METADATA: SceneRegistration = {
       step: 0.05,
       default: 0.5,
     },
-    PARTICLE_SHAPE_PARAM,
+    { ...PARTICLE_SHAPE_PARAM, default: 'streak' },
   ],
 };
 

--- a/src/components/visualizer/scenes/swarm-scene.ts
+++ b/src/components/visualizer/scenes/swarm-scene.ts
@@ -6,9 +6,10 @@ import {
   TEXTURE_SAMPLE_FN,
   PARTICLE_SHAPE_UNIFORM,
   PARTICLE_SHAPE_FN,
-  PARTICLE_SHAPE_INDEX,
   PARTICLE_SHAPE_PARAM,
   createTextureUniforms,
+  createParticleShapeUniform,
+  updateParticleShape,
   applyTextureTransform,
 } from './shader-chunks';
 import type { SceneRegistration, TextureTransform } from './types';
@@ -165,10 +166,7 @@ export class SwarmScene {
         uPrimary: { value: new THREE.Color(palette.primary) },
         uSecondary: { value: new THREE.Color(palette.secondary) },
         uAccent: { value: new THREE.Color(palette.accent) },
-        uParticleShape: {
-          value:
-            PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
-        },
+        ...createParticleShapeUniform(config),
         ...createTextureUniforms(config),
       },
       transparent: true,
@@ -207,10 +205,7 @@ export class SwarmScene {
     if (config.textureScale !== undefined) {
       this.material.uniforms.uTextureScale.value = config.textureScale;
     }
-    if (config.sceneParams?.particleShape !== undefined) {
-      this.material.uniforms.uParticleShape.value =
-        PARTICLE_SHAPE_INDEX[config.sceneParams.particleShape as string] ?? 0;
-    }
+    if (config.sceneParams) updateParticleShape(this.material, config.sceneParams);
     this.config = { ...this.config, ...config };
   }
 

--- a/src/components/visualizer/scenes/swarm-scene.ts
+++ b/src/components/visualizer/scenes/swarm-scene.ts
@@ -4,6 +4,10 @@ import { registerScene } from './scene-registry';
 import {
   TEXTURE_UNIFORMS,
   TEXTURE_SAMPLE_FN,
+  PARTICLE_SHAPE_UNIFORM,
+  PARTICLE_SHAPE_FN,
+  PARTICLE_SHAPE_INDEX,
+  PARTICLE_SHAPE_PARAM,
   createTextureUniforms,
   applyTextureTransform,
 } from './shader-chunks';
@@ -66,6 +70,8 @@ export class SwarmScene {
   private static FRAGMENT = `
     ${TEXTURE_UNIFORMS}
     ${TEXTURE_SAMPLE_FN}
+    ${PARTICLE_SHAPE_UNIFORM}
+    ${PARTICLE_SHAPE_FN}
     uniform float uHigh;
     uniform vec3 uPrimary;
     uniform vec3 uSecondary;
@@ -88,10 +94,8 @@ export class SwarmScene {
         alpha = texSample.a * (0.5 + closeness * 0.5);
         if (alpha < 0.01) discard;
       } else {
-        if (d > 0.5) discard;
-        float glow = exp(-d * 4.0);
-        float softEdge = 1.0 - smoothstep(0.2, 0.5, d);
-        alpha = (softEdge * 0.7 + glow * 0.3) * (0.5 + closeness * 0.5);
+        alpha = particleShapeAlpha(gl_PointCoord, uParticleShape) * (0.5 + closeness * 0.5);
+        if (alpha < 0.01) discard;
       }
 
       // Color distributed by per-particle attribute
@@ -161,6 +165,10 @@ export class SwarmScene {
         uPrimary: { value: new THREE.Color(palette.primary) },
         uSecondary: { value: new THREE.Color(palette.secondary) },
         uAccent: { value: new THREE.Color(palette.accent) },
+        uParticleShape: {
+          value:
+            PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
+        },
         ...createTextureUniforms(config),
       },
       transparent: true,
@@ -199,6 +207,10 @@ export class SwarmScene {
     if (config.textureScale !== undefined) {
       this.material.uniforms.uTextureScale.value = config.textureScale;
     }
+    if (config.sceneParams?.particleShape !== undefined) {
+      this.material.uniforms.uParticleShape.value =
+        PARTICLE_SHAPE_INDEX[config.sceneParams.particleShape as string] ?? 0;
+    }
     this.config = { ...this.config, ...config };
   }
 
@@ -236,6 +248,7 @@ const METADATA: SceneRegistration = {
       step: 0.05,
       default: 0.5,
     },
+    PARTICLE_SHAPE_PARAM,
   ],
 };
 

--- a/src/components/visualizer/scenes/vortex-scene.ts
+++ b/src/components/visualizer/scenes/vortex-scene.ts
@@ -4,6 +4,10 @@ import { registerScene } from './scene-registry';
 import {
   TEXTURE_UNIFORMS,
   TEXTURE_SAMPLE_FN,
+  PARTICLE_SHAPE_UNIFORM,
+  PARTICLE_SHAPE_FN,
+  PARTICLE_SHAPE_INDEX,
+  PARTICLE_SHAPE_PARAM,
   createTextureUniforms,
   applyTextureTransform,
 } from './shader-chunks';
@@ -59,6 +63,8 @@ export class VortexScene {
   private static FRAGMENT = `
     ${TEXTURE_UNIFORMS}
     ${TEXTURE_SAMPLE_FN}
+    ${PARTICLE_SHAPE_UNIFORM}
+    ${PARTICLE_SHAPE_FN}
     uniform vec3 uPrimary;
     uniform vec3 uSecondary;
     uniform vec3 uAccent;
@@ -75,8 +81,8 @@ export class VortexScene {
         alpha = texSample.a;
         if (alpha < 0.01) discard;
       } else {
-        if (d > 0.5) discard;
-        alpha = smoothstep(0.5, 0.0, d) * 0.8;
+        alpha = particleShapeAlpha(gl_PointCoord, uParticleShape) * 0.8;
+        if (alpha < 0.01) discard;
       }
 
       float t = vRadius / 6.0;
@@ -131,6 +137,10 @@ export class VortexScene {
         uPrimary: { value: new THREE.Color(palette.primary) },
         uSecondary: { value: new THREE.Color(palette.secondary) },
         uAccent: { value: new THREE.Color(palette.accent) },
+        uParticleShape: {
+          value:
+            PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
+        },
         ...createTextureUniforms(config),
       },
       transparent: true,
@@ -179,6 +189,10 @@ export class VortexScene {
     if (config.textureScale !== undefined) {
       this.material.uniforms.uTextureScale.value = config.textureScale;
     }
+    if (config.sceneParams?.particleShape !== undefined) {
+      this.material.uniforms.uParticleShape.value =
+        PARTICLE_SHAPE_INDEX[config.sceneParams.particleShape as string] ?? 0;
+    }
     this.config = { ...this.config, ...config };
   }
 
@@ -218,6 +232,7 @@ const METADATA: SceneRegistration = {
       step: 0.05,
       default: 0.5,
     },
+    PARTICLE_SHAPE_PARAM,
   ],
 };
 

--- a/src/components/visualizer/scenes/vortex-scene.ts
+++ b/src/components/visualizer/scenes/vortex-scene.ts
@@ -6,9 +6,10 @@ import {
   TEXTURE_SAMPLE_FN,
   PARTICLE_SHAPE_UNIFORM,
   PARTICLE_SHAPE_FN,
-  PARTICLE_SHAPE_INDEX,
   PARTICLE_SHAPE_PARAM,
   createTextureUniforms,
+  createParticleShapeUniform,
+  updateParticleShape,
   applyTextureTransform,
 } from './shader-chunks';
 import type { SceneRegistration, TextureTransform } from './types';
@@ -137,10 +138,7 @@ export class VortexScene {
         uPrimary: { value: new THREE.Color(palette.primary) },
         uSecondary: { value: new THREE.Color(palette.secondary) },
         uAccent: { value: new THREE.Color(palette.accent) },
-        uParticleShape: {
-          value:
-            PARTICLE_SHAPE_INDEX[(config.sceneParams?.particleShape as string) ?? 'circle'] ?? 0,
-        },
+        ...createParticleShapeUniform(config),
         ...createTextureUniforms(config),
       },
       transparent: true,
@@ -189,10 +187,7 @@ export class VortexScene {
     if (config.textureScale !== undefined) {
       this.material.uniforms.uTextureScale.value = config.textureScale;
     }
-    if (config.sceneParams?.particleShape !== undefined) {
-      this.material.uniforms.uParticleShape.value =
-        PARTICLE_SHAPE_INDEX[config.sceneParams.particleShape as string] ?? 0;
-    }
+    if (config.sceneParams) updateParticleShape(this.material, config.sceneParams);
     this.config = { ...this.config, ...config };
   }
 

--- a/src/components/visualizer/visualizer-settings-panel.tsx
+++ b/src/components/visualizer/visualizer-settings-panel.tsx
@@ -993,9 +993,9 @@ export function VisualizerSettingsPanel({
                   <SliderControl
                     label="Texture Size"
                     value={config.textureScale ?? 1.0}
-                    min={0.2}
-                    max={3}
-                    step={0.1}
+                    min={0.05}
+                    max={5}
+                    step={0.05}
                     onChange={(v) => onQuickChange({ textureScale: v })}
                   />
                 )}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -20,7 +20,7 @@ export const VisualizerConfigSchema = z.object({
   depth: z.number().min(0).max(1),
   colorCycleSpeed: z.number().min(0).max(2),
   customTextureUrl: z.string().nullable(),
-  textureScale: z.number().min(0.2).max(3),
+  textureScale: z.number().min(0.05).max(5),
   textureOpacity: z.number().min(0).max(1),
   textureAnimation: z.enum(['none', 'pulse', 'breathe', 'flash', 'strobe']),
   textureMotion: z


### PR DESCRIPTION
## Summary
- New experimental **Silhouette** scene that samples an uploaded texture's alpha channel as a pseudo-SDF inside a raymarch loop, turning the texture outline into glowing tunnel geometry
- Falls back to an animated diamond shape when no texture is loaded
- Adds `psychedelic` scene category (with label in settings panel)
- 4 scene params: Glow Density, Tunnel Speed, Shape Scale, Edge Width

## How it works
The fragment shader domain-repeats 3D space into tiles and, at each raymarch step, samples the texture alpha at the tile's xy position. `abs(alpha - 0.5)` produces zero at shape edges and 0.5 at interior/exterior, concentrating glow at the silhouette outline. Audio reactivity: bass scales shape + intensifies glow, mids control tunnel ripple, highs shift color.

## Test plan
- [ ] Select Silhouette scene with no texture — fallback diamond tunnel visible
- [ ] Upload a logo/icon texture — silhouette outline becomes the tunnel shape
- [ ] Adjust Shape Scale — texture fills more/less of each tile
- [ ] Adjust Edge Width — glow outline gets thicker/thinner
- [ ] Enable audio — bass/mid/high reactivity works
- [ ] Change palette — colors update
- [ ] Verify scene appears under "Psychedelic" category in settings panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)